### PR TITLE
Fixed: Failed to restore Vce vs. Ic scope setting. Added dump version No.

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -7,5 +7,6 @@
 			<attribute name="owner.project.facets" value="java"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="con" path="com.google.appengine.eclipse.core.GAE_CONTAINER"/>
 	<classpathentry kind="output" path="war/WEB-INF/classes"/>
 </classpath>

--- a/.project
+++ b/.project
@@ -25,10 +25,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>com.google.appengine.eclipse.core.enhancerbuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.google.appengine.eclipse.core.gaeProjectChangeNotifier</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>com.google.appengine.eclipse.core.projectValidator</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>com.google.gwt.eclipse.core.gwtNature</nature>
 		<nature>org.eclipse.wst.common.project.facet.core.nature</nature>
+		<nature>com.google.appengine.eclipse.core.gaeNature</nature>
 	</natures>
 </projectDescription>

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -1,5 +1,5 @@
 /*    
-    Copyright (C) Paul Falstad and Iain Sharp
+    Copyright (C) Paul Falstad, Iain Sharp and Dr. Matthew Swabey
     
     This file is part of CircuitJS1.
 
@@ -98,7 +98,7 @@ MouseOutHandler, MouseWheelHandler {
     
     public static final int sourceRadius = 7;
     public static final double freqMult = 3.14159265*2*4;
-    
+    public int currentDumpVersion = 0; //Hardcoded at 0 in case no version number is provided in string.
     
     
 //    public String getAppletInfo() {
@@ -226,6 +226,7 @@ MouseOutHandler, MouseWheelHandler {
     static ImportFromTextDialog importFromTextDialog;
     static ScrollValuePopup scrollValuePopup;
     static AboutBox aboutBox;
+    static ErrorBox errorBox;
 //    Class dumpTypes[], shortcuts[];
     String shortcuts[];
     static String muString = "u";
@@ -2594,7 +2595,8 @@ MouseOutHandler, MouseWheelHandler {
 	f |= (powerCheckItem.getState()) ? 8 : 0;
 	f |= (showValuesCheckItem.getState()) ? 0 : 16;
 	// 32 = linear scale in afilter
-	String dump = "$ " + f + " " +
+	String dump = "V " + " " + circuitjs1.maxDumpVersion + "\n"; //Add a version number to dump.
+	dump += "$ " + f + " " +
 	    timeStep + " " + getIterCount() + " " +
 	    currentBar.getValue() + " " + CircuitElm.voltageRange + " " +
 	    powerBar.getValue() + "\n";
@@ -2810,6 +2812,7 @@ MouseOutHandler, MouseWheelHandler {
 	    scopeCount = 0;
 	}
 	//cv.repaint();
+	currentDumpVersion = 0;
 	int p;
 	for (p = 0; p < len; ) {
 	    int l;
@@ -2827,6 +2830,13 @@ MouseOutHandler, MouseWheelHandler {
 		String type = st.nextToken();
 		int tint = type.charAt(0);
 		try {
+			if (tint == 'V') {
+				currentDumpVersion = new Integer(st.nextToken()).intValue();
+				if (currentDumpVersion < circuitjs1.minDumpVersion || currentDumpVersion > circuitjs1.maxDumpVersion) {
+					errorBox = new ErrorBox(circuitjs1.versionString, "Circuit String Version " + currentDumpVersion + " is not supported.");
+				}
+	    		break;
+			}
 		    if (tint == 'o') {
 			Scope sc = new Scope(this);
 			sc.position = scopeCount;

--- a/src/com/lushprojects/circuitjs1/client/ErrorBox.java
+++ b/src/com/lushprojects/circuitjs1/client/ErrorBox.java
@@ -38,30 +38,18 @@ import com.google.gwt.event.dom.client.MouseWheelHandler;
 import com.google.gwt.user.client.ui.HTML;
 import com.google.gwt.user.client.ui.Button;
 
-public class AboutBox extends PopupPanel {
+public class ErrorBox extends PopupPanel {
 	
 	VerticalPanel vp;
 	Button okButton;
 	
-	AboutBox(String version) {
+	ErrorBox(String version, String error) {
 		super();
 		vp = new VerticalPanel();
 		setWidget(vp);
 		vp.setWidth("400px");
 		vp.add(new HTML("<p>Circuit Simulator version "+version+".</p>"+
-		"<p>Original by Paul Falstad.<br><a href=\"http://www.falstad.com/\" target=\"_blank\">http://www.falstad.com/</a></p>"+
-		"<p>JavaScript conversion by Iain Sharp.<br><a href=\"http://lushprojects.com/\" target=\"_blank\">http://lushprojects.com/</a></p>"+
-		"<p>Bugfixes by Dr. Matthew Swabey.<br><a href=\"http://mattaw.blogspot.com/\" target=\"_blank\">http://mattaw.blogspot.com/</a></p>"+
-		"<p style=\"font-size:9px\">This program is free software: you can redistribute it and/or modify it "+
-		"under the terms of the GNU General Public License as published by "+
-		"the Free Software Foundation, either version 2 of the License, or "+
-		"(at your option) any later version.</p>"+
-		"<p style=\"font-size:9px\">This program is distributed in the hope that it will be useful,"+
-		"but WITHOUT ANY WARRANTY; without even the implied warranty of "+
-		"MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the "+
-		"GNU General Public License for more details.</p>"+
-		"<p style=\"font-size:9px\">For details of licensing see <A href=\"http://www.gnu.org/licenses/\" target=\"_blank\">http://www.gnu.org/licenses/</A>.</p>"+
-		"<p style=\"font-size:9px\">Source code:<A href=\"https://github.com/sharpie7/circuitjs1\" target=\"_blank\">https://github.com/sharpie7/circuitjs1</A></p>"));
+		"<p>Error: "+error+"</p>"));
 		vp.add(okButton = new Button("OK"));
 		okButton.addClickHandler(new ClickHandler() {
 			public void onClick(ClickEvent event) {

--- a/src/com/lushprojects/circuitjs1/client/Scope.java
+++ b/src/com/lushprojects/circuitjs1/client/Scope.java
@@ -1,5 +1,5 @@
 /*    
-    Copyright (C) Paul Falstad and Iain Sharp
+    Copyright (C) Paul Falstad, Iain Sharp and Dr. Matthew Swabey
     
     This file is part of CircuitJS1.
 
@@ -658,8 +658,9 @@ class Scope {
     	if (eno < 0)
     		return null;
     	int yno = yElm == null ? -1 : sim.locateElm(yElm);
-    	String x = "o " + eno + " " +
-    			speed + " " + value + " " + flags + " " +
+    	// Updated string to write out ivalue as we are dumping version 1
+    	String x =  "o " + eno + " " +
+    			speed + " " + value + " " + ivalue + " " + flags + " " +
     			minMaxV + " " + minMaxI + " " + position + " " + yno;
     	if (text != null)
     		x += " " + text;
@@ -674,6 +675,7 @@ class Scope {
     	elm = sim.getElm(e);
     	speed = new Integer(st.nextToken()).intValue();
     	value = new Integer(st.nextToken()).intValue();
+    	if (sim.currentDumpVersion == 1) ivalue = new Integer(st.nextToken()).intValue();
     	int flags = new Integer(st.nextToken()).intValue();
     	minMaxV = new Double(st.nextToken()).doubleValue();
     	minMaxI = new Double(st.nextToken()).doubleValue();

--- a/src/com/lushprojects/circuitjs1/client/circuitjs1.java
+++ b/src/com/lushprojects/circuitjs1/client/circuitjs1.java
@@ -1,5 +1,5 @@
 /*    
-    Copyright (C) Paul Falstad and Iain Sharp
+    Copyright (C) Paul Falstad, Iain Sharp and Dr. Matthew Swabey
     
     This file is part of CircuitJS1.
 
@@ -23,6 +23,7 @@ package com.lushprojects.circuitjs1.client;
 //GWT conversion (c) 2015 by Iain Sharp
 
 //Version History
+//v1.0.2 16-06-17 add a file version system to enable upgrades and bugfixes. Bugfix scope dump/load.
 //v1.0.1 15-06-15
 //Convert source code to GPLv2
 //Incorporate example files in to project
@@ -56,7 +57,9 @@ import com.google.gwt.user.client.Window;
 
 public class circuitjs1 implements EntryPoint {
 	
-	public static final String versionString="1.0.1";
+	public static final String versionString="1.0.2";
+	public static final int maxDumpVersion = 1;
+	public static final int minDumpVersion = 0;  
 
 	static CirSim mysim;
 	


### PR DESCRIPTION
Symptom: Setup a circuit involving a transistor. Add transistor to
scope. Right click "Show Vce vs. Ic". Export by any means. Import by any
means. Scope now shows "Show Vce".

Fix: 
1) Add version token "V 1\n" to the circuit CirSim.dumpCircuit() method.
Look for V <int> in CirSim.readSetup(). If int lies in range
maxDumpVersion to minDumpVersion store in currentDumpVersion. Otherwise
pop up ErrorBox() with message. Defaults to 0 if no version specified by
dump to maintain compatibility.

2) Tweaked Scope.dump() function to include ivalue. Tweaked
Scope.unDump() to test file version and if it is 1 then restores ivalue
from dump tokens correctly.

Minor:
Tweaked version number to 1.0.2
Updated copyright on touched files.
Updated about box to include author.