### PR TITLE
fix escape() to escape a bunch of characters that can't be used in links

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CustomLogicModel.java
+++ b/src/com/lushprojects/circuitjs1/client/CustomLogicModel.java
@@ -221,7 +221,8 @@ public class CustomLogicModel implements Editable {
     static String escape(String s) {
 	if (s.length() == 0)
 	    return "\\0";
-	return s.replace("\\", "\\\\").replace("\n", "\\n").replace(" ", "\\s").replace("+", "\\p");
+	return s.replace("\\", "\\\\").replace("\n", "\\n").replace(" ", "\\s").replace("+", "\\p").
+		replace("=", "\\q").replace("#", "\\h").replace("&", "\\a");
     }
     
     static String unescape(String s) {
@@ -237,6 +238,12 @@ public class CustomLogicModel implements Editable {
 		    s = s.substring(0, i) + " " + s.substring(i+2);
 		else if (c == 'p')
 		    s = s.substring(0, i) + "+" + s.substring(i+2);
+		else if (c == 'q')
+		    s = s.substring(0, i) + "=" + s.substring(i+2);
+		else if (c == 'h')
+		    s = s.substring(0, i) + "#" + s.substring(i+2);
+		else if (c == 'a')
+		    s = s.substring(0, i) + "&" + s.substring(i+2);
 		else
 		    s = s.substring(0, i) + s.substring(i+1);
 	    }

--- a/src/com/lushprojects/circuitjs1/client/TextElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TextElm.java
@@ -30,6 +30,7 @@ class TextElm extends GraphicElm {
     int size;
     final int FLAG_CENTER = 1;
     final int FLAG_BAR = 2;
+    final int FLAG_ESCAPE = 4;
     public TextElm(int xx, int yy) {
 	super(xx, yy);
 	text = "hello";
@@ -42,9 +43,15 @@ class TextElm extends GraphicElm {
 	super(xa, ya, xb, yb, f);
 	size = new Integer(st.nextToken()).intValue();
 	text = st.nextToken();
-	while (st.hasMoreTokens())
-	    text += ' ' + st.nextToken();
-	text=text.replaceAll("%2[bB]", "+");
+	if ((flags & FLAG_ESCAPE) == 0) {
+	    // old-style dump before escape/unescape
+	    while (st.hasMoreTokens())
+		text += ' ' + st.nextToken();
+	    text=text.replaceAll("%2[bB]", "+");
+	} else {
+	    // new-style dump
+	    text = CustomLogicModel.unescape(text); 
+	}
 	split();
     }
     void split() {
@@ -67,7 +74,8 @@ class TextElm extends GraphicElm {
 	lines.add(sb.toString());
     }
     String dump() {
-	return super.dump() + " " + size + " " + text.replaceAll("\\+","%2B");
+	flags |= FLAG_ESCAPE;
+	return super.dump() + " " + size + " " + CustomLogicModel.escape(text);
 	//return super.dump() + " " + size + " " + text;
     }
     int getDumpType() { return 'x'; }


### PR DESCRIPTION
fix TextElm to use escape() to protect those same characters in links