### PR TITLE
Remove unused fields from class CirSim

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -95,9 +95,6 @@ MouseOutHandler, MouseWheelHandler {
     
     Random random;
     
-    public static final int sourceRadius = 7;
-    public static final double freqMult = 3.14159265*2*4;
-
     // IES - remove interaction
     Button resetButton;
     Button runStopButton;
@@ -187,7 +184,6 @@ MouseOutHandler, MouseWheelHandler {
     long zoomTime;
     int mouseCursorX = -1;
     int mouseCursorY = -1;
-    int selectedSource;
     Rectangle selectedArea;
     int gridSize, gridMask, gridRound;
     boolean dragging;
@@ -1032,7 +1028,6 @@ MouseOutHandler, MouseWheelHandler {
     	return new Rectangle(minx, miny, maxx-minx, maxy-miny);
     }
 
-    static final int resct = 6;
     long lastTime = 0, lastFrameTime, lastIterTime, secTime = 0;
     int frames = 0;
     int steps = 0;


### PR DESCRIPTION
Remove several orphaned fields from the CirSim class. Not only are
these fields currently unused, there is no sign that they have ever
been used, going back to the Java version 1.3e from August 1, 2008.
