### PR TITLE
Small timing fix for very slow simulation speeds.

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -2420,7 +2420,9 @@ MouseOutHandler, MouseWheelHandler {
 	    	scopes[i].timeStep();
 	    tm = System.currentTimeMillis();
 	    lit = tm;
-	    if (iter*1000 >= steprate*(tm-lastIterTime) || (tm-lastFrameTime > 500))
+	    // Check whether enough time has elapsed to perform an *additional* iteration after
+	    // those we have already completed.
+	    if ((iter+1)*1000 >= steprate*(tm-lastIterTime) || (tm-lastFrameTime > 500))
 		break;
 	} // for (iter = 1; ; iter++)
 	lastIterTime = lit;


### PR DESCRIPTION
Although the simulator allowed you to set its simulation speed control
low enough to allow timestep advance rates down to a minimum of one
timestep per second, it failed to actually run that slowly. It almost
always performed at least two timesteps in the iteration loop in
runCircuit(), regardless of how low the speed was set, because the first
timing condition on whether to run another iteration had an off-by-one
error. This meant that at very low simulation speeds the simulator
always ran about twice as fast as would be indicated by runCircuit()'s
"steprate" variable, which gives the expected rate in timesteps per
second.

This very small fix corrects the logic of the faulty iteration timing
condition. The condition now checks whether enough time has passed that
an *additional* iteration should be run to maintain the desired
timestep rate. This is, after all, what we are actually trying to
check.

Testing the fix shows that the simulator can now be run at speeds down
to one timestep per second, and in general very low simulation speeds
match or nearly match the value of "steprate". High simulation speeds
are not significantly affected.