### PR TITLE
CirSim.java: lu_factor() - clean up and simplify singular matrix check

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -4133,24 +4133,21 @@ MouseOutHandler, MouseWheelHandler {
     // matrix to be factored.  ipvt[] returns an integer vector of pivot
     // indices, used in the lu_solve() routine.
     boolean lu_factor(double a[][], int n, int ipvt[]) {
-	double scaleFactors[];
 	int i,j,k;
-
-	scaleFactors = new double[n];
 	
-        // divide each row by its largest element, keeping track of the
-	// scaling factors
+	// check for a possible singular matrix by scanning for rows that
+	// are all zeroes
 	for (i = 0; i != n; i++) { 
-	    double largest = 0;
+	    boolean row_all_zeros = true;
 	    for (j = 0; j != n; j++) {
-		double x = Math.abs(a[i][j]);
-		if (x > largest)
-		    largest = x;
+		if (a[i][j] != 0) {
+		    row_all_zeros = false;
+		    break;
+		}
 	    }
 	    // if all zeros, it's a singular matrix
-	    if (largest == 0)
+	    if (row_all_zeros)
 		return false;
-	    scaleFactors[i] = 1.0/largest;
 	}
 	
         // use Crout's method; loop through the columns
@@ -4187,7 +4184,6 @@ MouseOutHandler, MouseWheelHandler {
 		    a[largestRow][k] = a[j][k];
 		    a[j][k] = x;
 		}
-		scaleFactors[largestRow] = scaleFactors[j];
 	    }
 
 	    // keep track of row interchanges


### PR DESCRIPTION
lu_factor() would create and update a local temporary array
scaleFactors[] with scaling factors for the matrix, but it never used
the values in the array for anything; it was simply wasted work. This
code has been in the simulator at least since 1.3g from November 2008.

This commit eliminates this array and all references to it.

It also restructures lu_factor()'s initial test for a singular matrix
with a row of all zeroes. Since we're no longer building scale factors,
instead of scanning each row for the element with the largest
magnitude, we simply scan it for any nonzero elements. As soon as we
find such an element, we stop scanning that row and skip on to the next
one. Only if all the elements in the row are zero do we return false
to signal a singular matrix.

I've tested this change a fair amount. While it may have a small
performance benefit for nonlinear circuits, which must call lu_factor()
for every timestep, this is probably insignificant. Mainly it just
simplifies the logic a little.