### PR TITLE
Adjust Diode model to make behavior closer to real discrete diodes.

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ZenerElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ZenerElm.java
@@ -36,10 +36,6 @@ class ZenerElm extends DiodeElm {
 	zvoltage = new Double(st.nextToken()).doubleValue();
 	setup();
     }
-    void setup() {
-	diode.leakage = 5e-6; // 1N4004 is 5.0 uAmp
-	super.setup();
-    }
     int getDumpType() { return 'z'; }
     String dump() {
 	return super.dump() + " " + zvoltage;


### PR DESCRIPTION
The Diode class simulates the behavior of standard diodes, Zener
diodes, and LEDs. This commit, which I have tested on all the sample
circuits which either have diodes of some form, or have components
that make use of the class (including the JFET and the SCR), makes
several significant changes to the diode model:

* Change how the forward voltage setting works. Previously it set the
  thermal voltage "vt", which had the effect of changing the steepness
  of the diode's exponential curve. (The default value for forward
  voltage corresponded to vt = 0.025.) Now it sets the diode's scale
  current "leakage", so it does not affect the exponential's steepness
  of the exponential, only its overall scale. vt has been fixed at
  0.025865, the same value used by the BJT model in TransistorElm,
  corresponding to a standard temperature of 27 C (300 K).

* Change the exponential profile for diodes. A new variable "emcoef",
  representing the emission coefficient in the diode equation, has
  been added, and its value has been fixed at 2, which better matches
  the exponential profile of many common discrete diodes. This has two
  effects: it makes the diode exponential only half as steep as
  before, and, for any given forward voltage setting, it makes the
  scale current "leakage" much larger (roughly the square root of the
  value which would have been used before). So currents in reverse
  bias, while still very small, are much bigger than before, which also
  better matches real discrete diodes. These two effects have the
  additional benefit of making convergence easier for some circuits
  in which the former steeper exponential and tiny reverse-biased
  current could cause difficulty.

* Change Zener diodes to use an exponential profile steeper than
  normal for Zener breakdown only. In the non-Zener region, Zener
  diodes now use the same less-steep exponential that normal diodes
  use. However, the Zener breakdown region still uses the original
  steep exponential, without the effect of the emission coefficient.
  This makes the Zener breakdown curve steeper than the forward-biased
  curve, which is closer to how real Zeners act.

* Remove the clamping of the diode exponential for negative voltages.
  Instead set the parallel conductance "gmin" to a small nonzero value
  (1% of "leakage") from the very first subiteration, to help
  convergence and prevent underflows that can cause a singular matrix.
  This is similar to what is now done in TransistorElm.

* Remove the adjustments in limitStep() which prevented voltage
  limiting from reducing the new voltage below a value that would
  produce 1 uA of current. This seemed to me like an unnecessary
  change in SPICE's voltage-limiting algorithm which could have
  unintended effects.