### PR TITLE
Make transformers reset properly.

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/TappedTransformerElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TappedTransformerElm.java
@@ -76,8 +76,6 @@ package com.lushprojects.circuitjs1.client;
 	    for (i = 0; i != 4; i += 2) {
 		drawThickLine(g, ptCore[i], ptCore[i+1]);
 	    }
-	    // calc current of tap wire
-	    current[3] = current[1]-current[2];
 	    for (i = 0; i != 4; i++)
 		curcount[i] = updateDotCount(current[i], curcount[i]);
 
@@ -127,8 +125,12 @@ package com.lushprojects.circuitjs1.client;
 	}
 	int getPostCount() { return 5; }
 	void reset() {
-	    current[0] = current[1] = current[2] = volts[0] = volts[1] = volts[2] =
+	    current[0] = current[1] = current[2] = current[3] = volts[0] = volts[1] = volts[2] =
 		volts[3] = volts[4] = curcount[0] = curcount[1] = curcount[2] = 0;
+	    // need to set current-source values here in case one of the nodes is node 0.  In that case
+	    // calculateCurrent() may get called (from setNodeVoltage()) when analyzing circuit, before
+	    // startIteration() gets called
+	    curSourceValue[0] = curSourceValue[1] = curSourceValue[2] = 0;
 	}
 	double a[];
 	void stamp() {
@@ -216,6 +218,8 @@ package com.lushprojects.circuitjs1.client;
 		for (j = 0; j != 3; j++)
 		    current[i] += a[i*3+j]*voltdiff[j];
 	    }
+	    // calc current of tap wire
+	    current[3] = current[1]-current[2];
 	}
 	void getInfo(String arr[]) {
 	    arr[0] = "transformer";

--- a/src/com/lushprojects/circuitjs1/client/TransformerElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TransformerElm.java
@@ -132,8 +132,11 @@ package com.lushprojects.circuitjs1.client;
 	}
 	int getPostCount() { return 4; }
 	void reset() {
+	    // need to set current-source values here in case one of the nodes is node 0.  In that case
+	    // calculateCurrent() may get called (from setNodeVoltage()) when analyzing circuit, before
+	    // startIteration() gets called
 	    current[0] = current[1] = volts[0] = volts[1] = volts[2] =
-		volts[3] = curcount[0] = curcount[1] = 0;
+		volts[3] = curcount[0] = curcount[1] = curSourceValue1 = curSourceValue2 = 0;
 	}
 	double a1, a2, a3, a4;
 	void stamp() {


### PR DESCRIPTION
This change fixes the reset behavior for both TransformerElm and
TappedTransformerElm. The reset() method for both of these classes
was not zeroing their current-source variables; this has now been
fixed.

(The following explanation is probably already familiar, since I
simply patterned this fix off of existing fixes already done for
capacitors and inductors. I'm including it for the benefit of
future readers of this commit.)

Suppose one of the transformer's nodes is the ground node. For
example, this can easily happen in a simple circuit with a
two-terminal voltage source directly connected to the transformer,
since if the circuit has no ground element, one of the voltage source
terminals will be assigned to the ground node. During the circuit's
initial analysis, setNodeVoltage() will be called for each circuit
element connected to the ground node, to ensure that node is set
to 0 volts. But setNodeVoltage() will in turn call the element's
calculateCurrent() method. For transformers, this method will set
the current variables using the existing values for the current-source
variables, just as it does for each integration step. If reset() does
not zero the current-source variables along with the current variables,
the current may thus end up with a non-zero value after reset. So to
reset the transformer properly, reset() must also zero its
current-source variables.

In addition to this fix, I did a small cleanup in TappedTransformerElm,
moving the setting of current[3] (which contains the *net* current
through the secondary's center tap) from inside the draw() method to
the end of the calculateCurrent() method, which seemed a more
appropriate place. Just to be safe and consistent, current[3] is also
zeroed on reset(), like the other current variables.