### PR TITLE
Responsive UI design for mobile devices

### DIFF
--- a/src/com/lushprojects/circuitjs1/circuitjs1.gwt.xml
+++ b/src/com/lushprojects/circuitjs1/circuitjs1.gwt.xml
@@ -4,4 +4,5 @@
     <inherits name="com.google.gwt.http.HTTP" />
     <inherits name='com.google.gwt.user.theme.clean.Clean'/>
     <entry-point class="com.lushprojects.circuitjs1.client.circuitjs1" />
+    <stylesheet src='/circuitjs1/style.css' />
  </module>

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -36,7 +36,6 @@ import java.lang.Math;
 import com.google.gwt.canvas.client.Canvas;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CellPanel;
-import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.Label;
@@ -81,8 +80,6 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.DoubleClickHandler;
 import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.dom.client.CanvasElement;
-import com.google.gwt.dom.client.Document;
-import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -91,7 +88,6 @@ import com.google.gwt.storage.client.Storage;
 import com.google.gwt.user.client.ui.PopupPanel;
 import static com.google.gwt.event.dom.client.KeyCodes.*;
 import com.google.gwt.user.client.ui.Frame;
-import com.google.gwt.user.client.ui.HasHorizontalAlignment;
 import com.google.gwt.user.client.ui.Widget;
 import com.google.gwt.user.client.Window.Navigator;
 
@@ -405,13 +401,22 @@ MouseOutHandler, MouseWheelHandler {
 	  menuBar = new MenuBar();
 	  menuBar.addItem(LS("File"), fileMenuBar); 
 	  verticalPanel=new VerticalPanel();
+	  
+
 	  verticalPanel.getElement().addClassName("verticalPanel");
-	  Element checkbox = DOM.createInputCheck();
-	  Element label = DOM.createLabel();
-	  label.addClassName("triggerLabel");
-	  checkbox.setId("trigger");
-	  label.setAttribute("for", "trigger" );
-	  checkbox.addClassName("trigger");
+	  Element sidePanelCheckbox = DOM.createInputCheck();
+	  Element sidePanelCheckboxLabel = DOM.createLabel();
+	  sidePanelCheckboxLabel.addClassName("triggerLabel");
+	  sidePanelCheckbox.setId("trigger");
+	  sidePanelCheckboxLabel.setAttribute("for", "trigger" );
+	  sidePanelCheckbox.addClassName("trigger");
+	  Element topPanelCheckbox = DOM.createInputCheck(); 
+	  Element topPanelCheckboxLabel = DOM.createLabel();
+	  topPanelCheckbox.setId("toptrigger");
+	  topPanelCheckbox.addClassName("toptrigger");
+	  topPanelCheckboxLabel.addClassName("toptriggerlabel");
+	  topPanelCheckboxLabel.setAttribute("for", "toptrigger");
+
 
 	  
 
@@ -533,9 +538,11 @@ MouseOutHandler, MouseWheelHandler {
 	loadShortcuts();
 
 	  
-	  layoutPanel.addNorth(menuBar, MENUBARHEIGHT);
-	  DOM.appendChild(layoutPanel.getElement(), checkbox);
-	  DOM.appendChild(layoutPanel.getElement(), label);
+	  DOM.appendChild(layoutPanel.getElement(), topPanelCheckbox);
+	  DOM.appendChild(layoutPanel.getElement(), topPanelCheckboxLabel);	
+	  layoutPanel.addNorth(menuBar, MENUBARHEIGHT);	  
+	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckbox);
+	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckboxLabel);	  
 	  layoutPanel.addEast(verticalPanel, VERTICALPANELWIDTH);
 	  RootLayoutPanel.get().add(layoutPanel);
 	

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -58,6 +58,8 @@ import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.dom.client.MouseWheelHandler;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Unit;
@@ -404,6 +406,8 @@ MouseOutHandler, MouseWheelHandler {
 	  
 
 	  verticalPanel.getElement().addClassName("verticalPanel");
+	  verticalPanel.getElement().setId("painel");
+	  //verticalPanel.getElement().setAttribute("onclick", "document.getElementById('painel').style.opacity = 0");
 	  Element sidePanelCheckbox = DOM.createInputCheck();
 	  Element sidePanelCheckboxLabel = DOM.createLabel();
 	  sidePanelCheckboxLabel.addClassName("triggerLabel");
@@ -446,7 +450,7 @@ MouseOutHandler, MouseWheelHandler {
 
 	MenuBar drawMenuBar = new MenuBar(true);
 	drawMenuBar.setAutoOpen(true);
-
+	
 	menuBar.addItem(LS("Draw"), drawMenuBar);
 	
 	m = new MenuBar(true);
@@ -536,11 +540,28 @@ MouseOutHandler, MouseWheelHandler {
 	composeMainMenu(mainMenuBar);
 	composeMainMenu(drawMenuBar);
 	loadShortcuts();
+	
+//	//creates another menubar for mobile devices
+//	MenuBar menuBarMobile = new MenuBar(true);
+//	//composeMainMenu(menuBarMobile);
+//	//composeMainMenu(drawMenuBar);
+//	 menuBarMobile.getElement().addClassName("menuBarMobile");
+//	 menuBarMobile.getElement().setAttribute("onclick", "document.getElementsByClassName('toptrigger')[0].checked = 0");
 
 	  
 	  DOM.appendChild(layoutPanel.getElement(), topPanelCheckbox);
 	  DOM.appendChild(layoutPanel.getElement(), topPanelCheckboxLabel);	
-	  layoutPanel.addNorth(menuBar, MENUBARHEIGHT);	  
+	  layoutPanel.addNorth(menuBar, MENUBARHEIGHT);
+	  
+	  menuBar.getElement().insertFirst(menuBar.getElement().getChild(1));
+	  menuBar.getElement().getFirstChildElement().setAttribute("onclick", "document.getElementsByClassName('toptrigger')[0].checked = false");
+
+	  //creates a clone of the menubar for mobile devices
+	  //Element menuBarMobile = DOM.clone(menuBar.getElement(), true);
+	 
+//	  DOM.appendChild(layoutPanel.getElement(), menuBarMobile.getElement());
+	  
+	  
 	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckbox);
 	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckboxLabel);	  
 	  layoutPanel.addEast(verticalPanel, VERTICALPANELWIDTH);
@@ -688,7 +709,7 @@ MouseOutHandler, MouseWheelHandler {
 		      }
 		    }, ClickEvent.getType());	
 		Event.addNativePreviewHandler(this);
-		cv.addMouseWheelHandler(this);
+		cv.addMouseWheelHandler(this);		
 		setSimRunning(true);
     }
 

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -58,8 +58,6 @@ import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.dom.client.MouseWheelHandler;
-import com.google.gwt.event.logical.shared.ResizeEvent;
-import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Unit;
@@ -803,6 +801,7 @@ MouseOutHandler, MouseWheelHandler {
 	cv.addEventListener("touchstart", function (e) {
         	mousePos = getTouchPos(cv, e);
   		var touch = e.touches[0];
+  		
   		var etype = "mousedown";
   		clearTimeout(tmout);
   		if (e.timeStamp-lastTap < 300) {
@@ -818,6 +817,7 @@ MouseOutHandler, MouseWheelHandler {
     			clientX: touch.clientX,
     			clientY: touch.clientY
   		});
+  		
   		e.preventDefault();
   		cv.dispatchEvent(mouseEvent);
 	}, false);
@@ -843,9 +843,7 @@ MouseOutHandler, MouseWheelHandler {
   		var rect = canvasDom.getBoundingClientRect();
   		return {
     			x: touchEvent.touches[0].clientX - rect.left,
-//			x: touchEvent.touches[0].clientX,
     			y: touchEvent.touches[0].clientY - rect.top
-//    			y: touchEvent.touches[0].clientY
   		};
 	}
 	

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -36,6 +36,7 @@ import java.lang.Math;
 import com.google.gwt.canvas.client.Canvas;
 import com.google.gwt.user.client.ui.Button;
 import com.google.gwt.user.client.ui.CellPanel;
+import com.google.gwt.user.client.ui.CheckBox;
 import com.google.gwt.user.client.ui.DialogBox;
 import com.google.gwt.user.client.ui.DockLayoutPanel;
 import com.google.gwt.user.client.ui.Label;
@@ -68,6 +69,8 @@ import com.google.gwt.http.client.RequestBuilder;
 import com.google.gwt.http.client.RequestCallback;
 import com.google.gwt.user.client.ui.MenuBar;
 import com.google.gwt.user.client.Command;
+import com.google.gwt.user.client.DOM;
+import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
@@ -78,6 +81,8 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.DoubleClickHandler;
 import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.dom.client.CanvasElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.InputElement;
 import com.google.gwt.dom.client.NativeEvent;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.safehtml.shared.SafeHtml;
@@ -233,6 +238,7 @@ MouseOutHandler, MouseWheelHandler {
 	MenuBar menuBar;
 	MenuBar fileMenuBar;
 	VerticalPanel verticalPanel;
+
 	CellPanel buttonPanel;
 	private boolean mouseDragging;
 	double scopeHeightFraction=0.2;
@@ -386,7 +392,7 @@ MouseOutHandler, MouseWheelHandler {
 	  fileMenuBar.addItem(printItem);
 	  fileMenuBar.addSeparator();
 	  aboutItem=new MenuItem(LS("About..."),(Command)null);
-	  fileMenuBar.addItem(aboutItem);
+	  fileMenuBar.addItem(aboutItem);	
 	  aboutItem.setScheduledCommand(new MyCommand("file","about"));
 	  
 	  int width=(int)RootLayoutPanel.get().getOffsetWidth();
@@ -397,8 +403,18 @@ MouseOutHandler, MouseWheelHandler {
 	      VERTICALPANELWIDTH = 128;
 
 	  menuBar = new MenuBar();
-	  menuBar.addItem(LS("File"), fileMenuBar);
+	  menuBar.addItem(LS("File"), fileMenuBar); 
 	  verticalPanel=new VerticalPanel();
+	  verticalPanel.getElement().addClassName("verticalPanel");
+	  Element checkbox = DOM.createInputCheck();
+	  Element label = DOM.createLabel();
+	  label.addClassName("triggerLabel");
+	  checkbox.setId("trigger");
+	  label.setAttribute("for", "trigger" );
+	  checkbox.addClassName("trigger");
+
+	  
+
 	  
 	  // make buttons side by side if there's room
 	  buttonPanel=(VERTICALPANELWIDTH == 166) ? new HorizontalPanel() : new VerticalPanel();
@@ -518,6 +534,8 @@ MouseOutHandler, MouseWheelHandler {
 
 	  
 	  layoutPanel.addNorth(menuBar, MENUBARHEIGHT);
+	  DOM.appendChild(layoutPanel.getElement(), checkbox);
+	  DOM.appendChild(layoutPanel.getElement(), label);
 	  layoutPanel.addEast(verticalPanel, VERTICALPANELWIDTH);
 	  RootLayoutPanel.get().add(layoutPanel);
 	

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -58,8 +58,6 @@ import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.dom.client.MouseWheelHandler;
-import com.google.gwt.event.logical.shared.CloseEvent;
-import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Unit;
@@ -407,7 +405,6 @@ MouseOutHandler, MouseWheelHandler {
 
 	  verticalPanel.getElement().addClassName("verticalPanel");
 	  verticalPanel.getElement().setId("painel");
-	  //verticalPanel.getElement().setAttribute("onclick", "document.getElementById('painel').style.opacity = 0");
 	  Element sidePanelCheckbox = DOM.createInputCheck();
 	  Element sidePanelCheckboxLabel = DOM.createLabel();
 	  sidePanelCheckboxLabel.addClassName("triggerLabel");
@@ -540,30 +537,14 @@ MouseOutHandler, MouseWheelHandler {
 	composeMainMenu(mainMenuBar);
 	composeMainMenu(drawMenuBar);
 	loadShortcuts();
-	
-//	//creates another menubar for mobile devices
-//	MenuBar menuBarMobile = new MenuBar(true);
-//	//composeMainMenu(menuBarMobile);
-//	//composeMainMenu(drawMenuBar);
-//	 menuBarMobile.getElement().addClassName("menuBarMobile");
-//	 menuBarMobile.getElement().setAttribute("onclick", "document.getElementsByClassName('toptrigger')[0].checked = 0");
-
 	  
 	  DOM.appendChild(layoutPanel.getElement(), topPanelCheckbox);
 	  DOM.appendChild(layoutPanel.getElement(), topPanelCheckboxLabel);	
 	  layoutPanel.addNorth(menuBar, MENUBARHEIGHT);
-	  
 	  menuBar.getElement().insertFirst(menuBar.getElement().getChild(1));
 	  menuBar.getElement().getFirstChildElement().setAttribute("onclick", "document.getElementsByClassName('toptrigger')[0].checked = false");
-
-	  //creates a clone of the menubar for mobile devices
-	  //Element menuBarMobile = DOM.clone(menuBar.getElement(), true);
-	 
-//	  DOM.appendChild(layoutPanel.getElement(), menuBarMobile.getElement());
-	  
-	  
 	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckbox);
-	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckboxLabel);	  
+	  DOM.appendChild(layoutPanel.getElement(), sidePanelCheckboxLabel);
 	  layoutPanel.addEast(verticalPanel, VERTICALPANELWIDTH);
 	  RootLayoutPanel.get().add(layoutPanel);
 	

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -80,7 +80,10 @@ import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.DoubleClickHandler;
 import com.google.gwt.event.dom.client.DoubleClickEvent;
 import com.google.gwt.dom.client.CanvasElement;
+import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.MetaElement;
 import com.google.gwt.dom.client.NativeEvent;
+import com.google.gwt.dom.client.NodeList;
 import com.google.gwt.user.client.ui.MenuItem;
 import com.google.gwt.safehtml.shared.SafeHtml;
 import com.google.gwt.safehtml.shared.SafeHtmlUtils;
@@ -316,7 +319,14 @@ MouseOutHandler, MouseWheelHandler {
     
     public void init() {
 
+	//sets the meta tag to allow the css media queries to work
+	MetaElement meta = Document.get().createMetaElement();
+	meta.setName("viewport");
+	meta.setContent("width=device-width");
+	NodeList<com.google.gwt.dom.client.Element> node = Document.get().getElementsByTagName("head");
+	node.getItem(0).appendChild(meta);
 
+	
 	boolean printable = false;
 	boolean convention = true;
 	boolean euroRes = false;
@@ -829,8 +839,10 @@ MouseOutHandler, MouseWheelHandler {
 	function getTouchPos(canvasDom, touchEvent) {
   		var rect = canvasDom.getBoundingClientRect();
   		return {
-    			x: touchEvent.touches[0].clientX - rect.left,
-    			y: touchEvent.touches[0].clientY - rect.top
+//    			x: touchEvent.touches[0].clientX - rect.left,
+			x: touchEvent.touches[0].clientX,
+//    			y: touchEvent.touches[0].clientY - rect.top
+    			y: touchEvent.touches[0].clientY
   		};
 	}
 	

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -58,6 +58,8 @@ import com.google.gwt.user.client.Event.NativePreviewEvent;
 import com.google.gwt.user.client.Event.NativePreviewHandler;
 import com.google.gwt.event.dom.client.MouseWheelEvent;
 import com.google.gwt.event.dom.client.MouseWheelHandler;
+import com.google.gwt.event.logical.shared.ResizeEvent;
+import com.google.gwt.event.logical.shared.ResizeHandler;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.core.client.Scheduler;
 import com.google.gwt.dom.client.Style.Unit;
@@ -276,7 +278,8 @@ MouseOutHandler, MouseWheelHandler {
     	width=(int)RootLayoutPanel.get().getOffsetWidth();
     	height=(int)RootLayoutPanel.get().getOffsetHeight();
     	height=height-MENUBARHEIGHT;
-    	width=width-VERTICALPANELWIDTH;
+    	//not needed anymore since the width of the canvas' container div is set to 100% in ths CSS file
+    	//width=width-VERTICALPANELWIDTH;
 		if (cv != null) {
 			cv.setWidth(width + "PX");
 			cv.setHeight(height + "PX");
@@ -839,10 +842,10 @@ MouseOutHandler, MouseWheelHandler {
 	function getTouchPos(canvasDom, touchEvent) {
   		var rect = canvasDom.getBoundingClientRect();
   		return {
-//    			x: touchEvent.touches[0].clientX - rect.left,
-			x: touchEvent.touches[0].clientX,
-//    			y: touchEvent.touches[0].clientY - rect.top
-    			y: touchEvent.touches[0].clientY
+    			x: touchEvent.touches[0].clientX - rect.left,
+//			x: touchEvent.touches[0].clientX,
+    			y: touchEvent.touches[0].clientY - rect.top
+//    			y: touchEvent.touches[0].clientY
   		};
 	}
 	

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -9,50 +9,21 @@
 }
 
 .triggerLabel {
-	border-radius: 10px 0px 0px 10px;
-	background: white;
-	width: 20px;
-	height: 50px;
-	position: absolute;
-	top: 50px;
-	right: 166px;
-	z-index: 1;
-	transition: right 1s;
-}
-
-.trigger:checked+.triggerLabel {
-	right: 0;
-}
-
-/* selects the side panel */
-.trigger+.triggerLabel+div {
-	z-index: 1;
-	transition: width 1s;
-}
-
-.trigger:checked+.triggerLabel+div {
-	width: 0 !important;
-}
-
-/* selects the div containing the canvas */
-.trigger+.triggerLabel+div+div {
-	width: 100%;
-	transition: width 1s;
-}
-
-/* selects the the canvas */
-.trigger+.triggerLabel+div+div>canvas {
-	transition: width 1s;
-	width: 100%;
-}
-
-.trigger:checked+.triggerLabel+div+div>canvas {
-	width: 100% !important;
+	display: none;
 }
 
 @media only screen and (max-width: 600px) {
 	.triggerLabel {
+		display: initial;
+		border-radius: 10px 0px 0px 10px;
+		background: white;
+		width: 20px;
+		height: 50px;
+		position: absolute;
+		top: 50px;
 		right: 0;
+		z-index: 1;
+		transition: right 1s;
 	}
 	.triggerLabel:before {
 		content: "‖";
@@ -86,6 +57,8 @@
 	.trigger+.triggerLabel+div {
 		width: 0 !important;
 		background: white;
+		z-index: 1;
+		transition: width 1s;
 	}
 	.trigger:checked+.triggerLabel+div {
 		width: 166px !important;
@@ -131,5 +104,10 @@
 	.menuPopupMiddleCenterInner>div>table {
 		width: 100%;
 		text-align: center;
+	}
+	.menuPopupTopLeft, .menuPopupTopCenter, .menuPopupTopRight,
+		.menuPopupMiddleLeft, .menuPopupMiddleRight, .menuPopupMiddleCenter,
+		.menuPopupBottomLeft, .menuPopupBottomCenter, .menuPopupBottomRight {
+		background: white !important;
 	}
 }

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -1,25 +1,11 @@
 @charset "UTF-8";
 
-.trigger {
-	display: none;
-}
-
-.toptrigger {
-	display: none;
-}
-
-.triggerLabel {
-	display: none;
-}
-
-.menuBarMobile {
+/*Hide all mobile elements when in desktop usage*/
+.trigger, .toptrigger, .triggerLabel, toptriggerlabel {
 	display: none;
 }
 
 @media only screen and (max-width: 600px) {
-	.gwt-MenuBar-horizontal>table {
-		display: none;
-	}
 	.triggerLabel {
 		display: initial;
 		border-radius: 10px 0px 0px 10px;
@@ -66,9 +52,13 @@
 	.trigger:checked+.triggerLabel {
 		right: 128px;
 	}
-	.toptrigger:checked+label+div>div {
-		display: block !important;
+
+	/* selects the top panel */
+	.gwt-MenuBar-horizontal>table {
+		display: none;
 	}
+
+	/* shows the top menu when the user taps the menu icon */
 	.toptrigger:checked+label+div>div>table {
 		display: block !important;
 	}
@@ -84,16 +74,7 @@
 		width: 128px !important;
 	}
 
-	/* selects the div containing the canvas */
-	.trigger+.triggerLabel+div+div {
-		width: 100%;
-		height: 100%;
-	}
-
-	/* selects the canvas */
-	.trigger+.triggerLabel+div+div>canvas {
-		width: 100% !important;
-	}
+	/* selects the top menu */
 	.gwt-MenuBar-horizontal>table {
 		height: auto;
 		position: fixed;
@@ -111,9 +92,6 @@
 		width: 100%;
 		left: 0 !important;
 	}
-	.menuPopupMiddleCenter {
-		background: white;
-	}
 	.gwt-MenuBarPopup>div>table {
 		z-index: 2;
 		width: 100%;
@@ -128,5 +106,16 @@
 		.menuPopupMiddleLeft, .menuPopupMiddleRight, .menuPopupMiddleCenter,
 		.menuPopupBottomLeft, .menuPopupBottomCenter, .menuPopupBottomRight {
 		background: white !important;
+	}
+
+	/* selects the div containing the canvas */
+	.trigger+.triggerLabel+div+div {
+		width: 100% !important;
+	}
+
+	/* selects the canvas */
+	.trigger+.triggerLabel+div+div>canvas {
+		position: relative;
+		width: 100% !important;
 	}
 }

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -113,9 +113,5 @@
 		width: 100% !important;
 	}
 
-	/* selects the canvas */
-	.trigger+.triggerLabel+div+div>canvas {
-		position: relative;
-		width: 100% !important;
-	}
+
 }

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -12,7 +12,14 @@
 	display: none;
 }
 
+.menuBarMobile {
+	display: none;
+}
+
 @media only screen and (max-width: 600px) {
+	.gwt-MenuBar-horizontal {
+		display: none;
+	}
 	.triggerLabel {
 		display: initial;
 		border-radius: 10px 0px 0px 10px;
@@ -46,11 +53,24 @@
 		padding-left: 2px;
 		pointer-events: none;
 	}
-	.toptrigger:checked+label+div>div>table {
-		display: initial;
+
+	/*Trick to hide the menu when the user taps out of the menu*/
+	.toptrigger:checked {
+		display: block;
+		opacity: 0;
+		width: 100%;
+		height: 100%;
+		z-index: 2;
+		position: absolute;
 	}
 	.trigger:checked+.triggerLabel {
 		right: 166px;
+	}
+	.toptrigger:checked+label+div>div {
+		display: block !important;
+	}
+	.toptrigger:checked+label+div>div>table {
+		display: block !important;
 	}
 
 	/* selects the side panel */
@@ -79,7 +99,6 @@
 		position: fixed;
 		width: 100%;
 		text-align: center;
-		display: none;
 		top: 30px;
 		background: white;
 		z-index: 2;

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -17,7 +17,7 @@
 }
 
 @media only screen and (max-width: 600px) {
-	.gwt-MenuBar-horizontal {
+	.gwt-MenuBar-horizontal>table {
 		display: none;
 	}
 	.triggerLabel {
@@ -64,7 +64,7 @@
 		position: absolute;
 	}
 	.trigger:checked+.triggerLabel {
-		right: 166px;
+		right: 128px;
 	}
 	.toptrigger:checked+label+div>div {
 		display: block !important;
@@ -81,7 +81,7 @@
 		transition: width 1s;
 	}
 	.trigger:checked+.triggerLabel+div {
-		width: 166px !important;
+		width: 128px !important;
 	}
 
 	/* selects the div containing the canvas */

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -1,53 +1,135 @@
-body {
-  color: blue;
-  margin: 10px;
-  border: 0px;
-  padding: 0px;
-  background: #fff;
-  direct
+@charset "UTF-8";
+
+.trigger {
+	display: none;
 }
 
-.trigger{
-	transition: right 1s;
+.toptrigger {
+	display: none;
 }
 
-
-.triggerLabel{
+.triggerLabel {
 	border-radius: 10px 0px 0px 10px;
-	background:white;
-	width:20px;
-	height:50px;
-	position:absolute;
-	top:50px;
-	right:166px;
-	z-index:1;
+	background: white;
+	width: 20px;
+	height: 50px;
+	position: absolute;
+	top: 50px;
+	right: 166px;
+	z-index: 1;
 	transition: right 1s;
 }
 
-.trigger:checked + .triggerLabel{
-	right:0;
+.trigger:checked+.triggerLabel {
+	right: 0;
 }
 
-.trigger + .triggerLabel + div{
-z-index:1;
-transition: width 1s;
+/* selects the side panel */
+.trigger+.triggerLabel+div {
+	z-index: 1;
+	transition: width 1s;
 }
 
-.trigger:checked + .triggerLabel + div{
-	width:0 !important;
-
+.trigger:checked+.triggerLabel+div {
+	width: 0 !important;
 }
 
-.trigger + .triggerLabel + div +div {
-width:100%;
+/* selects the div containing the canvas */
+.trigger+.triggerLabel+div+div {
+	width: 100%;
+	transition: width 1s;
 }
 
-.trigger + .triggerLabel + div +div >canvas{
-transition: width 1s;
-width:100%;
+/* selects the the canvas */
+.trigger+.triggerLabel+div+div>canvas {
+	transition: width 1s;
+	width: 100%;
 }
 
-.trigger:checked + .triggerLabel + div +div >canvas{
-	width:100% !important;
-	
+.trigger:checked+.triggerLabel+div+div>canvas {
+	width: 100% !important;
+}
+
+@media only screen and (max-width: 600px) {
+	.triggerLabel {
+		right: 0;
+	}
+	.triggerLabel:before {
+		content: "‖";
+		font-size: 32px;
+		padding-left: 3px;
+		position: absolute;
+		padding-top: 5px;
+	}
+	.toptriggerlabel {
+		z-index: 1;
+		top: 5px;
+		right: 5px;
+		width: 20px;
+		height: 20px;
+		position: absolute;
+	}
+	.toptriggerlabel:before {
+		content: "☰";
+		font-size: 16px;
+		padding-left: 2px;
+		pointer-events: none;
+	}
+	.toptrigger:checked+label+div>div>table {
+		display: initial;
+	}
+	.trigger:checked+.triggerLabel {
+		right: 166px;
+	}
+
+	/* selects the side panel */
+	.trigger+.triggerLabel+div {
+		width: 0 !important;
+		background: white;
+	}
+	.trigger:checked+.triggerLabel+div {
+		width: 166px !important;
+	}
+
+	/* selects the div containing the canvas */
+	.trigger+.triggerLabel+div+div {
+		width: 100%;
+		height: 100%;
+	}
+
+	/* selects the canvas */
+	.trigger+.triggerLabel+div+div>canvas {
+		width: 100% !important;
+	}
+	.gwt-MenuBar-horizontal>table {
+		height: auto;
+		position: fixed;
+		width: 100%;
+		text-align: center;
+		display: none;
+		top: 30px;
+		background: white;
+		z-index: 2;
+	}
+	.gwt-MenuBar-horizontal * {
+		display: block;
+	}
+	.gwt-MenuBarPopup {
+		z-index: 2;
+		width: 100%;
+		left: 0 !important;
+	}
+	.menuPopupMiddleCenter {
+		background: white;
+	}
+	.gwt-MenuBarPopup>div>table {
+		z-index: 2;
+		width: 100%;
+		height: 300px;
+		position: fixed;
+	}
+	.menuPopupMiddleCenterInner>div>table {
+		width: 100%;
+		text-align: center;
+	}
 }

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -92,11 +92,17 @@
 		width: 100%;
 		left: 0 !important;
 	}
-	.gwt-MenuBarPopup>div>table {
+	.gwt-MenuBarPopup>div {
+		overflow: scroll;
 		z-index: 2;
 		width: 100%;
 		height: 300px;
 		position: fixed;
+		top: 30px;
+	}
+	.gwt-MenuBarPopup>div>table {
+		width: 100%;
+		height: 100%;
 	}
 	.menuPopupMiddleCenterInner>div>table {
 		width: 100%;
@@ -112,6 +118,4 @@
 	.trigger+.triggerLabel+div+div {
 		width: 100% !important;
 	}
-
-
 }

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -1,0 +1,53 @@
+body {
+  color: blue;
+  margin: 10px;
+  border: 0px;
+  padding: 0px;
+  background: #fff;
+  direct
+}
+
+.trigger{
+	transition: right 1s;
+}
+
+
+.triggerLabel{
+	border-radius: 10px 0px 0px 10px;
+	background:white;
+	width:20px;
+	height:50px;
+	position:absolute;
+	top:50px;
+	right:166px;
+	z-index:1;
+	transition: right 1s;
+}
+
+.trigger:checked + .triggerLabel{
+	right:0;
+}
+
+.trigger + .triggerLabel + div{
+z-index:1;
+transition: width 1s;
+}
+
+.trigger:checked + .triggerLabel + div{
+	width:0 !important;
+
+}
+
+.trigger + .triggerLabel + div +div {
+width:100%;
+}
+
+.trigger + .triggerLabel + div +div >canvas{
+transition: width 1s;
+width:100%;
+}
+
+.trigger:checked + .triggerLabel + div +div >canvas{
+	width:100% !important;
+	
+}

--- a/src/com/lushprojects/circuitjs1/public/style.css
+++ b/src/com/lushprojects/circuitjs1/public/style.css
@@ -99,6 +99,8 @@
 		height: 300px;
 		position: fixed;
 		top: 30px;
+		/* trick to prevent sub menus from opening in the same touch */
+		transition:all 0.1s;
 	}
 	.gwt-MenuBarPopup>div>table {
 		width: 100%;


### PR DESCRIPTION
I have been using the simulator for some time and I thought it would be a good idea to have a responsive UI to make it easier to use on mobile devices. 
Since gwt doesn't support any equivalent to css media rules, I had to add a custom css file to the project. It's declared in the circuitjs1.gwt.xml and located in /circuitjs1/style.css.

The top menu was turned in a hamburger menu and the side panel isn't displayed by default and behaves like a side navigation menu.
You can see how it looks in the following gif:
![ScreenRecord-2020-01-31-21-14-48](https://user-images.githubusercontent.com/22774765/73583572-c4162400-4471-11ea-9e23-8b9d8f12a89d.gif)

I tried to make as few changes as possible in other project files and made sure that no changes affected the standard desktop interface.
