### PR TITLE
added 48000 hz to audio output

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/AudioOutputElm.java
+++ b/src/com/lushprojects/circuitjs1/client/AudioOutputElm.java
@@ -135,7 +135,7 @@ public class AudioOutputElm extends CircuitElm {
 	    nextDataSample = sim.t+sampleStep;
 	}
 	
-	int samplingRateChoices[] = { 8000, 11025, 16000, 22050, 44100 };
+	int samplingRateChoices[] = { 8000, 11025, 16000, 22050, 44100, 48000 };
 	
 	public EditInfo getEditInfo(int n) {
 	    if (n == 0) {


### PR DESCRIPTION
I added 48000 hz as an audio output option, needed it for a sample to be used in arcade emulation/FPGA reimplementation for MiSTer Red Baron arcade module