### PR TITLE
Add lineOver to ring counter's reset pin

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/RingCounterElm.java
+++ b/src/com/lushprojects/circuitjs1/client/RingCounterElm.java
@@ -47,6 +47,7 @@ package com.lushprojects.circuitjs1.client;
 	    pins[0].clock = true;
 	    pins[1] = new Pin(sizeX-1, SIDE_S, "R");
 	    pins[1].bubble = true;
+	    pins[1].lineOver = true;
 	    int i;
 	    for (i = 0; i != bits; i++) {
 		int ii = i+2;

--- a/src/com/lushprojects/circuitjs1/client/RingCounterElm.java
+++ b/src/com/lushprojects/circuitjs1/client/RingCounterElm.java
@@ -46,7 +46,6 @@ package com.lushprojects.circuitjs1.client;
 	    pins[0] = new Pin(1, SIDE_W, "");
 	    pins[0].clock = true;
 	    pins[1] = new Pin(sizeX-1, SIDE_S, "R");
-	    pins[1].bubble = true;
 	    pins[1].lineOver = true;
 	    int i;
 	    for (i = 0; i != bits; i++) {


### PR DESCRIPTION
Circuitjs's ring counter has an active-low reset pin and is cleared with a low reset signal (this is distinct from the active-high reset pins of devices such as the CD4026BE). Unless I'm mistaken, I believe this should be marked with an overline.
I spent a solid 10 minutes trying to figure out why the ring counter was not working - the lack of marking suggested the reset pin is active-high, not active-low.
Related but not part of this commit: It would be nice to have an edit option to change whether or not the reset pin is active-high or active-low.