### PR TITLE
Fix clearing on model dialog

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
+++ b/src/com/lushprojects/circuitjs1/client/EditCompositeModelDialog.java
@@ -226,6 +226,7 @@ public class EditCompositeModelDialog extends DialogBox implements MouseDownHand
 	    double scaleh = context.getCanvas().getHeight() / (double)(chip.boundingBox.height + chip.boundingBox.y*2);
 	    scale = 1/Math.min(scalew, scaleh);
 	    context.setFillStyle(CirSim.theSim.getBackgroundColor().getHexValue());
+		context.setTransform(1, 0, 0, 1, 0, 0);
 	    context.fillRect(0, 0, context.getCanvas().getWidth(), context.getCanvas().getHeight());
 	    context.setTransform(1/scale, 0, 0, 1/scale, 0, 0);
 	    chip.draw(g);


### PR DESCRIPTION
This commit fixes a bug in the composite model (ie subcircuit) editor dialog where the chip display is not cleared properly, resulting in buffer garbage.
This bug occurs when the model is large and the camera is automatically zoomed out, and is caused by the rendering context having an undefined transform when clearing the background. Resetting the transform before clearing fixes this bug.