### PR TITLE
Add "# of Bits" edit info to ADC and DAC

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/ADCElm.java
+++ b/src/com/lushprojects/circuitjs1/client/ADCElm.java
@@ -53,5 +53,22 @@ class ADCElm extends ChipElm {
     int getVoltageSourceCount() { return bits; }
     int getPostCount() { return bits+2; }
     int getDumpType() { return 167; }
+    public EditInfo getEditInfo(int n) {
+        if (n < 2)
+            return super.getEditInfo(n);
+        if (n == 2)
+            return new EditInfo("# of Bits", bits, 1, 1).setDimensionless();
+        return null;
+    }
+    public void setEditValue(int n, EditInfo ei) {
+        if (n < 2) {
+            super.setEditValue(n,  ei);
+            return;
+        }
+        if (n == 2 && ei.value >= 2) {
+            bits = (int)ei.value;
+            setupPins();
+            setPoints();
+        }
+    }
 }
-    

--- a/src/com/lushprojects/circuitjs1/client/DACElm.java
+++ b/src/com/lushprojects/circuitjs1/client/DACElm.java
@@ -52,5 +52,22 @@ class DACElm extends ChipElm {
     int getVoltageSourceCount() { return 1; }
     int getPostCount() { return bits+2; }
     int getDumpType() { return 166; }
+    public EditInfo getEditInfo(int n) {
+        if (n < 2)
+            return super.getEditInfo(n);
+        if (n == 2)
+            return new EditInfo("# of Bits", bits, 1, 1).setDimensionless();
+        return null;
+    }
+    public void setEditValue(int n, EditInfo ei) {
+        if (n < 2) {
+            super.setEditValue(n,  ei);
+            return;
+        }
+        if (n == 2 && ei.value >= 2) {
+            bits = (int)ei.value;
+            setupPins();
+            setPoints();
+        }
+    }
 }
-    


### PR DESCRIPTION
I'm not sure why this hasn't been added until now. I tested it just in case it was omitted due to some kind of bug or inherent flaw, but it seems to work.
Test code (with 8 pin ADC to DAC):
`$ 1 0.000005 10.20027730826997 50 5 43 5e-11
166 256 160 288 160 0 8
167 160 160 192 160 0 8
R 160 384 160 336 0 0 40 5 0 0 0.5
w 160 384 160 416 0
w 160 416 352 416 0
w 352 416 352 384 0
R 160 160 112 160 0 3 10 2.5 2.5 0 0.5
O 352 160 400 160 1 1
o 7 16 0 4098 5 0.1 0 2 6 0
`