### PR TITLE
Add query parameter option "euroGates"

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ You can add query parameters to link to change the applications startup behaviou
 .../circuitjs.html?startCircuitLink=<URL> // Loads the circuit from the specified URL. CURRENTLY THE URL MUST BE A DROPBOX SHARED FILE OR ANOTHER URL THAT SUPPORTS CORS ACCESS FROM THE CLIENT
 .../circuitjs.html?euroResistors=true // Set to true to force "Euro" style resistors. If not specified the resistor style will be based on the user's browser's language preferences
 .../circuitjs.html?usResistors=true // Set to true to force "US" style resistors. If not specified the resistor style will be based on the user's browser's language preferences
+.../circuitjs.html?euroGates=true // Set to true to force "IEC" style logic gates. If not specified the gate style will be based on the user's browser's language preferences
 .../circuitjs.html?whiteBackground=<true|false>
 .../circuitjs.html?conventionalCurrent=<true|false>
 .../circuitjs.html?running=<true|false> // Start the app without the simulation running, default true

--- a/src/com/lushprojects/circuitjs1/client/CirSim.java
+++ b/src/com/lushprojects/circuitjs1/client/CirSim.java
@@ -354,6 +354,7 @@ MouseOutHandler, MouseWheelHandler {
 	boolean hideSidebar = false;
 	boolean hideMenu = false;
 	boolean noEditing = false;
+	boolean euroGates = getOptionFromStorage("euroGates", weAreInGermany());
 	MenuBar m;
 
 	CircuitElm.initClass(this);
@@ -378,6 +379,8 @@ MouseOutHandler, MouseWheelHandler {
 	    startCircuitLink = qp.getValue("startCircuitLink");
 	    euroRes = qp.getBooleanValue("euroResistors", false);
 	    usRes = qp.getBooleanValue("usResistors",  false);
+	    if (qp.getValue("euroGates")!=null)
+		euroGates = qp.getBooleanValue("euroGates", euroGates);
 	    running = qp.getBooleanValue("running", true);
 	    hideSidebar = qp.getBooleanValue("hideSidebar", false);
 	    hideMenu = qp.getBooleanValue("hideMenu", false);
@@ -396,7 +399,6 @@ MouseOutHandler, MouseWheelHandler {
 	    euroSetting = false;
 	else
 	    euroSetting = getOptionFromStorage("euroResistors", !weAreInUS());
-	boolean euroGates = getOptionFromStorage("euroGates", weAreInGermany());
 
 	transform = new double[6];
 	String os = Navigator.getPlatform();


### PR DESCRIPTION
Currently, IEC gates are by default selected when a German locale is
detected. This patch introduces a query parameter "euroGates" which
overrides the default locale setting if specified so that it is possible
to display ANSI gates by default even on a browser with German locale.