### PR TITLE
555 Timer's reset pin is active low, so should have bar over name

### DIFF
--- a/src/com/lushprojects/circuitjs1/client/TimerElm.java
+++ b/src/com/lushprojects/circuitjs1/client/TimerElm.java
@@ -51,6 +51,7 @@ class TimerElm extends ChipElm {
 	pins[N_OUT] = new Pin(2, SIDE_E, "out");
 	pins[N_OUT].state = true;
 	pins[N_RST] = new Pin(1, SIDE_E, "rst");
+	pins[N_RST].lineOver = true;
 	pins[N_GND] = new Pin(2, SIDE_S, "gnd");
     }
     boolean nonLinear() { return true; }


### PR DESCRIPTION
Active low pins typically use a naming convention that puts a bar over the name. For the most part, datasheets and wikipedia.org/wiki/555_timer_IC have a bar over the reset pin name. Circuitjs already puts a bar over the 555's trigger pin, so the reset pin should also have a bar.